### PR TITLE
Benchmarks needs more than 12h to be scheduled by the HPC clusters

### DIFF
--- a/benchmark/scripts/jobs/job-large.sbatch
+++ b/benchmark/scripts/jobs/job-large.sbatch
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 #SBATCH --mail-type=END,FAIL
 #SBATCH --job-name=LSMIO-LG
-#SBATCH --time=12:00:00
+#SBATCH --time=24:00:00
 #SBATCH --mem=8gb
 #SBATCH --ntasks-per-node=4
 #SBATCH --ntasks-per-socket=2

--- a/benchmark/scripts/jobs/job-small.sbatch
+++ b/benchmark/scripts/jobs/job-small.sbatch
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 #SBATCH --mail-type=END,FAIL
 #SBATCH --job-name=LSMIO-SM
-#SBATCH --time=12:00:00
+#SBATCH --time=24:00:00
 #SBATCH --mem=32gb
 #SBATCH --ntasks-per-node=1
 #SBATCH --ntasks-per-socket=1


### PR DESCRIPTION
The default value 12h is too low for a benchmark job to be scheduled. Set it to 24h.